### PR TITLE
tell curl to follow 302

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
         jq \
         openssl
 
-RUN DOCKER_GEN_VERSION=$(curl -s https://api.github.com/repos/jwilder/docker-gen/releases/latest | grep 'tag_name' | cut -d\" -f4) \
+RUN DOCKER_GEN_VERSION=$(curl -sL https://api.github.com/repos/jwilder/docker-gen/releases/latest | grep 'tag_name' | cut -d\" -f4) \
     && wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
     && tar xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz -C /usr/local/bin \
     && rm docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz


### PR DESCRIPTION
This PR fixes a curl typo where redirects are not followed, and Docker build fails:

```
#6 0.596 --2021-06-17 19:04:32--  https://github.com/jwilder/docker-gen/releases/download//docker-gen-linux-amd64-.tar.gz                                                        
#6 0.619 Resolving github.com (github.com)... 140.82.121.3                                                                                                                       
#6 0.651 Connecting to github.com (github.com)|140.82.121.3|:443... connected.
#6 0.738 HTTP request sent, awaiting response... 301 Moved Permanently
#6 0.776 Location: https://github.com/nginx-proxy/docker-gen/releases/download/docker-gen-linux-amd64-.tar.gz [following]
#6 0.776 --2021-06-17 19:04:32--  https://github.com/nginx-proxy/docker-gen/releases/download/docker-gen-linux-amd64-.tar.gz
#6 0.777 Reusing existing connection to github.com:443.
#6 0.778 HTTP request sent, awaiting response... 404 Not Found
#6 0.847 2021-06-17 19:04:33 ERROR 404: Not Found.
```

