### PR TITLE
Remove generating only from exposed containers

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker-gen -only-exposed -watch -notify-output -notify "bash /tmp/cert" cert.tmpl /tmp/cert
+docker-gen -watch -notify-output -notify "bash /tmp/cert" cert.tmpl /tmp/cert


### PR DESCRIPTION
In newer docker versions, the -only-exposed flag will only generate a certificate if the container has mapped a port to the host system